### PR TITLE
LaTeX Compatibility

### DIFF
--- a/Smart Title Case.py
+++ b/Smart Title Case.py
@@ -9,8 +9,23 @@ class SmartTitleCaseCommand(sublime_plugin.TextCommand):
     def run(self, edit):
         for region in self.view.sel():
             if region.empty():
-                region = self.view.line(region)
+
+                line = self.view.line(region)
+                lineStr = self.view.substr(line)
+
+                relIndex = region.begin() - line.begin()
+
+                end = lineStr.find("}", relIndex)
+                sta = lineStr[::-1].find("{", len(lineStr) - relIndex)
+
+                if sta is not -1 and end is not -1:
+                    region = sublime.Region(line.begin() + (len(lineStr) - sta), line.begin() + end)
+
+                else:
+                    region = self.view.line(region)
 
             s = self.view.substr(region)
             s = titlecase(s)
             self.view.replace(edit, region, s)
+
+            print("tex: ", s)

--- a/Smart Title Case.py
+++ b/Smart Title Case.py
@@ -27,5 +27,3 @@ class SmartTitleCaseCommand(sublime_plugin.TextCommand):
             s = self.view.substr(region)
             s = titlecase(s)
             self.view.replace(edit, region, s)
-
-            print("tex: ", s)


### PR DESCRIPTION
Hi there,
I love your plugin. I use it mostly for some LaTex file. But it always bugged me that I cannot just capitalise e.g. `\section{please capitalise me}` without having to select the whole title (`please capitalise me`). Else the command `section` is capitalised and the first word after the opening curly bracket (`please`) did not get capitalised.
Therefore I implemented functionality for capitalising text between curly brackets by just placing the cursor somewhere between the brackets. Text outside the brackets is left unchanged.
Everything else stays unchanged.

Would love to hear what you think about it!
Kind regards 