### PR TITLE
whitelist Mc- and Mac- last names

### DIFF
--- a/titlecase/__init__.py
+++ b/titlecase/__init__.py
@@ -25,7 +25,7 @@ SUBPHRASE = re.compile(r'([:.;?!][ ])(%s)' % SMALL)
 APOS_SECOND = re.compile(r"^[dol]{1}['‘]{1}[a-z]+$", re.I)
 ALL_CAPS = re.compile(r'^[A-Z\s%s]+$' % PUNCT)
 UC_INITIALS = re.compile(r"^(?:[A-Z]{1}\.{1}|[A-Z]{1}\.{1}[A-Z]{1})+$")
-MAC_MC = re.compile(r"^([Mm]a?c)(\w+)")
+MAC_MC = re.compile(r"^([Mm]a?c(?=allen|alpin|arthur|cain|carthy|cartney|clellan|clintock|connell|cormack|cormick|court|coy|cullers|culloch|cullough|donald|donnell|enroe|govern|graw|guffey|guffin|gwire|gyver|job|keesport|kenna|kinley|kuen|lean|leish|luhan|master|minnville|murtry|namara|neil|phee|reynolds))(\w+)")
 
 def titlecase(text):
 


### PR DESCRIPTION
As noted in https://github.com/mattstevens/sublime-titlecase/issues/1, this extension works like a dream _except_ with words that start with "mc" or "mac", which get horribly butchered.

For instance:

```
macabre           =>  MacAbre
macadam           =>  MacAdam
macademia nut     =>  MacAdemia Nut
Macao             =>  MacAo
macaroni          =>  MacAroni
macaroon          =>  MacAroon
macaw             =>  MacAw
mace              =>  MacE
Macedonia         =>  MacEdonia
Mach five         =>  MacH Five
(Papier) Mache    =>  (Papier) MacHe
machete           =>  MacHete
machine           =>  MacHine
machine learning  =>  MacHine Learning
machinery         =>  MacHinery
machinist         =>  MacHinist
macho             =>  MacHo
macroeconomics    =>  MacRoeconomics
macrocosm         =>  MacRocosm
```

...which, I think you'll agree, is...not the desired behavior.

In fact, even a great many words that seem like surnames that _should_ get a second capital letter in fact do not. Consider:

```
Macauley
Macbeth
Maclean
Machiavelli
Macintosh
Mackenzie
Mackinac
Mackintosh
Macleod
```

_None_ of these should get a second capital in most cases.

This PR includes a whitelist for common names that generally _should_ get a second capital, so that other words beginning with "mac" will be properly left with a single capital.